### PR TITLE
add force true to stop previously not properly closed BrowserStack

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,8 @@ function createBrowserStackConnector (accessKey) {
             forceLocal: !!process.env['BROWSERSTACK_FORCE_LOCAL'],
             forceProxy: !!process.env['BROWSERSTACK_FORCE_PROXY'],
 
+            force: true, //Stop previously not properly closed BrowserStack client before run
+
             //NOTE: additional args use different format
             'enable-logging-for-api': true
         };


### PR DESCRIPTION
Hello! Thank you for the awesome tool. We [AutoScout24.com](http://autoscout24.com) using it for our interaction.
We use gulp-testcafe and testcafe-browser-provider-browserstack together.
We've got small issue:
If we stop gulp task by **'CTRL+C'** then on next time we get 
```
Message:
    Was unable to open the browser "browserstack:Chrome@53.0:Windows 10" due to error.

Either another browserstack local client is running on your machine or some server is listening on port 45691
(node:32926) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): LocalError: Either another browserstack local client is running on your machine or some server is listening on port 45691
(node:32926) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

```

By adding `force: true`, previously not closed client will stop and we can run new test without errors.
