### PR TITLE
Allow specifying project name and build name.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
   - stable
-  - '0.10'
+  - '4'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ npm install testcafe-browser-provider-browserstack
 ## Usage
 Before using this plugin, save the BrowserStack username and access key to environment variables `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY`.
 
+Project name and build name will be displayed in BrowserStack if you set the environment variables `BROWSERSTACK_PROJECT_NAME` and `BROWSERSTACK_BUILD_ID`.
+
 You can determine the available browser aliases by running
 ```
 testcafe -b browserstack

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.1",
   "description": "browserstack TestCafe browser provider plugin.",
   "repository": "https://github.com/DevExpress/testcafe-browser-provider-browserstack",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "homepage": "https://github.com/DevExpress/testcafe-browser-provider-browserstack",
   "author": {
     "name": "Andrey Belym",

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,9 @@ import jimp from 'jimp';
 import OS from 'os-family';
 import nodeUrl from 'url';
 
+const BUILD_ID = process.env['BROWSERSTACK_BUILD_ID'];
+const PROJECT_NAME = process.env['BROWSERSTACK_PROJECT_NAME'];
+
 const TESTS_TIMEOUT                = process.env['BROWSERSTACK_TEST_TIMEOUT'] || 1800;
 const BROWSERSTACK_CONNECTOR_DELAY = 10000;
 
@@ -129,6 +132,11 @@ function doRequest (apiPath, params) {
         auth: {
             user: process.env['BROWSERSTACK_USERNAME'],
             pass: process.env['BROWSERSTACK_ACCESS_KEY'],
+        },
+
+        qs: {
+            ...BUILD_ID && { build: BUILD_ID },
+            ...PROJECT_NAME && { project: PROJECT_NAME }
         },
 
         method: apiPath.method || 'GET',

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import { stringify as makeQueryString } from 'querystring';
 import Promise from 'pinkie';
 import request from 'request-promise';
 import parseCapabilities from 'desired-capabilities';
@@ -125,19 +124,17 @@ function doRequest (apiPath, params) {
 
     var url = apiPath.url;
 
-    if (params)
-        url += '?' + makeQueryString(params);
-
     var opts = {
         auth: {
             user: process.env['BROWSERSTACK_USERNAME'],
             pass: process.env['BROWSERSTACK_ACCESS_KEY'],
         },
 
-        qs: {
-            ...BUILD_ID && { build: BUILD_ID },
-            ...PROJECT_NAME && { project: PROJECT_NAME }
-        },
+        qs: Object.assign({},
+            BUILD_ID && { build: BUILD_ID },
+            PROJECT_NAME && { project: PROJECT_NAME },
+            params
+        ),
 
         method: apiPath.method || 'GET',
         json:   !apiPath.binaryStream

--- a/test/mocha/test.js
+++ b/test/mocha/test.js
@@ -29,8 +29,8 @@ describe('Browser names', function () {
                     'ie@11.0:Windows 8.1',
                     'edge@14.0:Windows 10',
                     'iPhone 6@8.3',
-                    'iPhone SE@10.0',
-                    'iPad Pro (9.7 inch)@10.0',
+                    'iPhone SE@10.3',
+                    'iPad Pro (9.7 inch)@10.3',
                     'Google Nexus 5@5.0'
                 ]);
             });


### PR DESCRIPTION
This fixes https://github.com/DevExpress/testcafe-browser-provider-browserstack/issues/11.

Get build name and project name from environment variables (`BROWSERSTACK_PROJECT_NAME`, `BROWSERSTACK_BUILD_ID`) and pass to BrowserStack.

We're running a lot of different TestCafe tests in BrowserStack in our organization, and currently it's difficult to identify them because the test run has a random ID and there is no project name.