### PR TITLE
Add option to set screen resolution when working with JS Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ testCafe
 
 Tip: you can skip version (`@53.0`) or/and OS name (`:Windows 10`).
 
+If you use JS testing (see [Browserstack JS Testing and Browserstack Automate](#browserstack-js-testing-and-browserstack-automate) below) and want to set the device resolution, use the `BROWSERSTACK_RESOLUTION` environment variable.
+Note for JS testing, changing the screen resolution during the test is not supported.
+So it can only be set once before the test starts.
+Supported resolutions can be found [here](https://github.com/browserstack/api#resolution).
+If you use Browserstack Automate, change the screen size with [TestCafe's native method](https://devexpress.github.io/testcafe/documentation/test-api/actions/resize-window.html). 
+
 ## Browserstack Proxy Options
 Proxy options can be passed via envrionment variables.
 

--- a/src/backends/js-testing.js
+++ b/src/backends/js-testing.js
@@ -6,7 +6,8 @@ import delay from '../utils/delay';
 import createBrowserstackStatus from '../utils/create-browserstack-status';
 
 
-const TESTS_TIMEOUT = process.env['BROWSERSTACK_TEST_TIMEOUT'] || 1800;
+const TESTS_TIMEOUT     = process.env['BROWSERSTACK_TEST_TIMEOUT'] || 1800;
+const SCREEN_RESOLUTION = process.env['BROWSERSTACK_RESOLUTION'] || '1024x768';
 
 const MINIMAL_WORKER_TIME        = 30000;
 const TESTCAFE_CLOSING_TIMEOUT   = 10000;
@@ -77,8 +78,9 @@ export default class JSTestingBackend extends BaseBackend {
         capabilities = {
             'browserstack.local': local,
 
-            timeout: TESTS_TIMEOUT,
-            url:     pageUrl,
+            timeout:    TESTS_TIMEOUT,
+            url:        pageUrl,
+            resolution: SCREEN_RESOLUTION,
 
             ...restCapabilities
         };

--- a/test/mocha/browser-names-test.js
+++ b/test/mocha/browser-names-test.js
@@ -27,7 +27,7 @@ describe('Browser names', function () {
                     'ie@9.0:Windows 7',
                     'ie@10.0:Windows 8',
                     'ie@11.0:Windows 8.1',
-                    'edge@14.0:Windows 10',
+                    'edge@15.0:Windows 10',
                     'iPhone 6@8.3',
                     'iPhone SE@11.2',
                     'iPad Pro@11.2',


### PR DESCRIPTION
In the readme of this repo it says that the resolution can only be set when using Browserstack Automate.
While this is true for dynamically setting the browser size, it is possible to set it for all tests to something else than 1204x768. 
This PR adds the ability to set the screen size before the test starts and it uses JS Testing.

(I also changed the test file since Edge 14 is not supported by Browserstack any more)