### PR TITLE
Add more browserstack capabilities

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,7 @@
     "no-spaced-func": "error",
     "no-undef-init": "error",
     "no-unused-expressions": "error",
+    "no-unused-vars": ["error", { "ignoreRestSiblings" : true }],
     "no-with": "error",
     "camelcase": "error",
     "comma-spacing": "error",

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ export BROWSERSTACK_DISPLAY_RESOLUTION="1024x768"
 testcafe browserstack:chrome test.js
 ```
 
-## Specyfing Chrome Command Line Arguments
+## Specifying Chrome Command Line Arguments
 
 To set [Chrome command line arguments](https://peter.sh/experiments/chromium-command-line-switches/), use the `BROWSERSTACK_CHROME_ARGS` environment variable. You can specify multiple arguments by joining them with the space symbol. This option works only if the [Browserstack Automate API is enabled](https://github.com/ondrejbartas/testcafe-browser-provider-browserstack/#browserstack-js-testing-and-browserstack-automate).
 
@@ -106,15 +106,29 @@ export BROWSERSTACK_CHROME_ARGS="--start-maximized --autoplay-policy=no-user-ges
 testcafe browserstack:chrome test.js
 ```
 
-## Extra capabilities
-
-Browserstack has a few more custom capabilities. You can find the expected values [here](https://www.browserstack.com/automate/capabilities).
-
-- `BROWSERSTACK_DEBUG`
-- `BROWSERSTACK_CONSOLE`
-- `BROWSERSTACK_NETWORK_LOGS`
-- `BROWSERSTACK_VIDEO`
-- `BROWSERSTACK_TIMEZONE`
+## Other BrowserStack Options
+ 
+BrowserStack Automate allows you to provide options for its internal Selenium Grid in the form of key-value pairs called [capabilities](https://www.browserstack.com/automate/capabilities).
+ 
+To specify BrowserStack capabilities via the TestCafe BrowserStack provider, use environment variables. This provider supports the following capabilities:
+ 
+Capability                 | Environment Variable
+-------------------------- | --------------------
+`browserstack.debug`       | `BROWSERSTACK_DEBUG`
+`browserstack.console`     | `BROWSERSTACK_CONSOLE`
+`browserstack.networkLogs` | `BROWSERSTACK_NETWORK_LOGS`
+`browserstack.video`       | `BROWSERSTACK_VIDEO`
+`browserstack.timezone`    | `BROWSERSTACK_TIMEZONE`
+ 
+Refer to the [BrowserStack documentation](https://www.browserstack.com/automate/capabilities) for information about the values you can specify.
+ 
+**Example**
+ 
+```sh
+export BROWSERSTACK_DEBUG="true"
+export BROWSERSTACK_TIMEZONE="UTC"
+testcafe browserstack:chrome test.js
+```
 
 ## Author
 Developer Express Inc. (https://devexpress.com)

--- a/README.md
+++ b/README.md
@@ -106,5 +106,15 @@ export BROWSERSTACK_CHROME_ARGS="--start-maximized --autoplay-policy=no-user-ges
 testcafe browserstack:chrome test.js
 ```
 
+## Extra capabilities
+
+Browserstack has a few more custom capabilities. You can find the expected values [here](https://www.browserstack.com/automate/capabilities).
+
+- `BROWSERSTACK_DEBUG`
+- `BROWSERSTACK_CONSOLE`
+- `BROWSERSTACK_NETWORK_LOGS`
+- `BROWSERSTACK_VIDEO`
+- `BROWSERSTACK_TIMEZONE`
+
 ## Author
 Developer Express Inc. (https://devexpress.com)

--- a/src/index.js
+++ b/src/index.js
@@ -26,34 +26,6 @@ export default {
     platformsInfo: [],
     browserNames:  [],
 
-    _getAdditionalCapabilities (capabilities) {
-        // NOTE: This function maps env vars to browserstack capabilities.
-        // For the full list of capabilities, see https://www.browserstack.com/automate/capabilities
-        const capabilitiesFromEnvironment = [
-            ['build', process.env['BROWSERSTACK_BUILD_ID']],
-            ['project', process.env['BROWSERSTACK_PROJECT_NAME']],
-            ['resolution', process.env['BROWSERSTACK_DISPLAY_RESOLUTION']],
-            ['browserstack.debug', process.env['BROWSERSTACK_DEBUG']],
-            ['browserstack.console', process.env['BROWSERSTACK_CONSOLE']],
-            ['browserstack.networkLogs', process.env['BROWSERSTACK_NETWORK_LOGS']],
-            ['browserstack.video', process.env['BROWSERSTACK_VIDEO']],
-            ['browserstack.timezone', process.env['BROWSERSTACK_TIMEZONE']],
-        ];
-
-        const additionalCapabilities = capabilitiesFromEnvironment
-            // eslint-disable-next-line no-unused-vars
-            .filter(([name, value]) => value !== void 0)
-            .reduce((result, [name, value]) => {
-                result[name] = value;
-                return result;
-            }, {});
-
-        return {
-            ...capabilities,
-            ...additionalCapabilities
-        };
-    },
-
     _getConnector () {
         this.connectorPromise = this.connectorPromise
             .then(async connector => {
@@ -127,8 +99,31 @@ export default {
         };
     },
 
-    _generateCapabilities (browserName) {
+    _generateBasicCapabilities (browserName) {
         return this._filterPlatformInfo(this._createQuery(browserName))[0];
+    },
+
+    _getAdditionalCapabilities () {
+        // NOTE: This function maps env vars to browserstack capabilities.
+        // For the full list of capabilities, see https://www.browserstack.com/automate/capabilities
+        const capabilitiesFromEnvironment = [
+            ['build', process.env['BROWSERSTACK_BUILD_ID']],
+            ['project', process.env['BROWSERSTACK_PROJECT_NAME']],
+            ['resolution', process.env['BROWSERSTACK_DISPLAY_RESOLUTION']],
+            ['browserstack.debug', process.env['BROWSERSTACK_DEBUG']],
+            ['browserstack.console', process.env['BROWSERSTACK_CONSOLE']],
+            ['browserstack.networkLogs', process.env['BROWSERSTACK_NETWORK_LOGS']],
+            ['browserstack.video', process.env['BROWSERSTACK_VIDEO']],
+            ['browserstack.timezone', process.env['BROWSERSTACK_TIMEZONE']],
+        ];
+
+        return capabilitiesFromEnvironment
+            .filter(([name, value]) => value !== void 0)
+            .reduce((result, [name, value]) => {
+                result[name] = value;
+            
+                return result;
+            }, {});
     },
 
     _filterPlatformInfo (query) {
@@ -171,7 +166,7 @@ export default {
     // Required - must be implemented
     // Browser control
     async openBrowser (id, pageUrl, browserName) {
-        var capabilities = this._getAdditionalCapabilities(this._generateCapabilities(browserName));
+        var capabilities = { ...this._generateBasicCapabilities(browserName), ...this._getAdditionalCapabilities() };
         var connector    = await this._getConnector();
 
         if (capabilities.os.toLowerCase() === 'android') {

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ export default {
         ];
 
         return capabilitiesFromEnvironment
-            .filter(([name, value]) => value !== void 0)
+            .filter(tuple => tuple.value !== void 0)
             .reduce((result, [name, value]) => {
                 result[name] = value;
             

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ export default {
         ];
 
         return capabilitiesFromEnvironment
-            .filter(tuple => tuple.value !== void 0)
+            .filter(nameValueTuple => nameValueTuple[1] !== void 0)
             .reduce((result, [name, value]) => {
                 result[name] = value;
             

--- a/src/index.js
+++ b/src/index.js
@@ -27,18 +27,31 @@ export default {
     browserNames:  [],
 
     _addEnvironmentPreferencesToCapabilities (capabilities) {
-        const BUILD_ID           = process.env['BROWSERSTACK_BUILD_ID'];
-        const PROJECT_NAME       = process.env['BROWSERSTACK_PROJECT_NAME'];
-        const DISPLAY_RESOLUTION = process.env['BROWSERSTACK_DISPLAY_RESOLUTION'];
+        /**
+         * This maps env var BROWSERSTACK_${key} to capabilities[value].
+         *
+         * For the full list of customized capabilities, see https://www.browserstack.com/automate/capabilities
+         */
+        const envToCapabilities = {
+            'BUILD_ID':           'build',
+            'PROJECT_NAME':       'project',
+            'DISPLAY_RESOLUTION': 'resolution',
+            'DEBUG':              'browserstack.debug',
+            'CONSOLE':            'browserstack.console',
+            'NETWORK_LOGS':       'browserstack.networkLogs',
+            'VIDEO':              'browserstack.video',
+            'TIMEZONE':           'browserstack.timezone',
+        };
 
-        if (PROJECT_NAME)
-            capabilities.project = PROJECT_NAME;
+        Object.keys(envToCapabilities).forEach((key) => {
+            const envName = 'BROWSERSTACK_' + key;
+            const value = process.env[envName];
+            const capName = envToCapabilities[key];
 
-        if (BUILD_ID)
-            capabilities.build = BUILD_ID;
-
-        if (DISPLAY_RESOLUTION)
-            capabilities.resolution = DISPLAY_RESOLUTION;
+            if (value) 
+                capabilities[capName] = value;
+            
+        });
     },
 
     _getConnector () {

--- a/test/mocha/browserstack-capabilities-test.js
+++ b/test/mocha/browserstack-capabilities-test.js
@@ -4,8 +4,6 @@ var browserStackProvider = require('../../');
 
 describe('Browserstack capabilities', function () {
     it('Should add custom capabilities from environment variables', function () {
-        const output = {};
-
         process.env['BROWSERSTACK_BUILD_ID'] = 'build-1';
         process.env['BROWSERSTACK_PROJECT_NAME'] = 'project-1';
         process.env['BROWSERSTACK_DISPLAY_RESOLUTION'] = '1024x768';
@@ -15,7 +13,7 @@ describe('Browserstack capabilities', function () {
         process.env['BROWSERSTACK_VIDEO'] = 'true';
         process.env['BROWSERSTACK_TIMEZONE'] = 'Asia/Taipei';
 
-        browserStackProvider._addEnvironmentPreferencesToCapabilities(output);
+        const output = browserStackProvider._getAdditionalCapabilities({});
 
         expect(output).to.deep.equal({
             'build':                    'build-1',

--- a/test/mocha/browserstack-capabilities-test.js
+++ b/test/mocha/browserstack-capabilities-test.js
@@ -1,0 +1,31 @@
+var expect               = require('chai').expect;
+var browserStackProvider = require('../../');
+
+
+describe('Browserstack capabilities', function () {
+    it('Should add custom capabilities from environment variables', function () {
+        const output = {};
+
+        process.env['BROWSERSTACK_BUILD_ID'] = 'build-1';
+        process.env['BROWSERSTACK_PROJECT_NAME'] = 'project-1';
+        process.env['BROWSERSTACK_DISPLAY_RESOLUTION'] = '1024x768';
+        process.env['BROWSERSTACK_DEBUG'] = 'true';
+        process.env['BROWSERSTACK_CONSOLE'] = 'errors';
+        process.env['BROWSERSTACK_NETWORK_LOGS'] = 'true';
+        process.env['BROWSERSTACK_VIDEO'] = 'true';
+        process.env['BROWSERSTACK_TIMEZONE'] = 'Asia/Taipei';
+
+        browserStackProvider._addEnvironmentPreferencesToCapabilities(output);
+
+        expect(output).to.deep.equal({
+            'build':                    'build-1',
+            'project':                  'project-1',
+            'resolution':               '1024x768',
+            'browserstack.debug':       'true',
+            'browserstack.console':     'errors',
+            'browserstack.networkLogs': 'true',
+            'browserstack.video':       'true',
+            'browserstack.timezone':    'Asia/Taipei'
+        });
+    });
+});


### PR DESCRIPTION
# Problem

I need access to more custom browserstack capabilities (console log, network log)

# Solution

Refactor the code a little bit to have a more generic mapping which makes future updates easier. Added support for:

- `BROWSERSTACK_DEBUG`
- `BROWSERSTACK_CONSOLE`
- `BROWSERSTACK_NETWORK_LOGS`
- `BROWSERSTACK_VIDEO`
- `BROWSERSTACK_TIMEZONE`