### PR TITLE
Add additional options to control BrowserStackLocal binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ export BROWSERSTACK_FORCE_LOCAL="1"
 testcafe browserstack:chrome test.js
 ```
 
+## Other BrowserStackLocal Options
+
+Option  | Environment Variable
+------  | --------------------
+[`logFile`](https://github.com/browserstack/browserstack-local-nodejs#logfile) | `BROWSERSTACK_LOGFILE`
+[`verbose`](https://github.com/browserstack/browserstack-local-nodejs#verbose-logging) | `BROWSERSTACK_VERBOSE`
+[`binarypath`](https://github.com/browserstack/browserstack-local-nodejs#binary-path) | `BROWSERSTACK_BINARY_PATH`
+
 ## Browserstack JS Testing and Browserstack Automate
 Browserstack offers two APIs for browser testing:
  - [Browserstack JS Testing](https://www.browserstack.com/javascript-testing-api)

--- a/README.md
+++ b/README.md
@@ -60,11 +60,21 @@ testcafe browserstack:chrome test.js
 
 ## Other BrowserStackLocal Options
 
+This plugin also allows you to specify the following [BrowserStackLocal](https://github.com/browserstack/browserstack-local-nodejs) options via environment variables:
+
 Option  | Environment Variable
 ------  | --------------------
-[`logFile`](https://github.com/browserstack/browserstack-local-nodejs#logfile) | `BROWSERSTACK_LOGFILE`
-[`verbose`](https://github.com/browserstack/browserstack-local-nodejs#verbose-logging) | `BROWSERSTACK_VERBOSE`
-[`binarypath`](https://github.com/browserstack/browserstack-local-nodejs#binary-path) | `BROWSERSTACK_BINARY_PATH`
+[binarypath](https://github.com/browserstack/browserstack-local-nodejs#binary-path) | `BROWSERSTACK_BINARY_PATH`
+[logFile](https://github.com/browserstack/browserstack-local-nodejs#logfile) | `BROWSERSTACK_LOGFILE`
+[verbose](https://github.com/browserstack/browserstack-local-nodejs#verbose-logging) | `BROWSERSTACK_VERBOSE`
+
+Example:
+```
+export BROWSERSTACK_BINARY_PATH="~/BrowserStack/BrowserStackLocal"
+export BROWSERSTACK_LOGFILE="~/BrowserStack/logs.txt"
+export BROWSERSTACK_VERBOSE="1"
+testcafe browserstack:chrome test.js
+```
 
 ## Browserstack JS Testing and Browserstack Automate
 Browserstack offers two APIs for browser testing:

--- a/src/connector.js
+++ b/src/connector.js
@@ -60,6 +60,7 @@ export default class BrowserstackConnector {
             var parallelRuns = process.env['BROWSERSTACK_PARALLEL_RUNS'];
             var logfile = process.env['BROWSERSTACK_LOGFILE'] || (OS.win ? this._getTempFileName() : '/dev/null');
             var verbose = process.env['BROWSERSTACK_VERBOSE'];
+            var binarypath = process.env['BROWSERSTACK_BINARY_PATH'];
 
             var opts = {
                 key:             this.accessKey,
@@ -70,6 +71,7 @@ export default class BrowserstackConnector {
 
                 ...parallelRuns ? { parallelRuns } : {},
                 ...verbose ? { verbose } : {},
+                ...binarypath ? { binarypath } : {},
 
                 //NOTE: additional args use different format
                 'enable-logging-for-api': true

--- a/src/connector.js
+++ b/src/connector.js
@@ -58,11 +58,11 @@ export default class BrowserstackConnector {
         return new Promise((resolve, reject) => {
             var connector    = new BrowserstackLocal();
             var parallelRuns = process.env['BROWSERSTACK_PARALLEL_RUNS'];
-
+            var logfile = process.env['BROWSERSTACK_LOGFILE'] || (OS.win ? this._getTempFileName() : '/dev/null');
 
             var opts = {
                 key:             this.accessKey,
-                logfile:         OS.win ? this._getTempFileName() : '/dev/null',
+                logfile,
                 forceLocal:      !!process.env['BROWSERSTACK_FORCE_LOCAL'],
                 forceProxy:      !!process.env['BROWSERSTACK_FORCE_PROXY'],
                 localIdentifier: Date.now(),

--- a/src/connector.js
+++ b/src/connector.js
@@ -59,6 +59,7 @@ export default class BrowserstackConnector {
             var connector    = new BrowserstackLocal();
             var parallelRuns = process.env['BROWSERSTACK_PARALLEL_RUNS'];
             var logfile = process.env['BROWSERSTACK_LOGFILE'] || (OS.win ? this._getTempFileName() : '/dev/null');
+            var verbose = process.env['BROWSERSTACK_VERBOSE'];
 
             var opts = {
                 key:             this.accessKey,
@@ -68,6 +69,7 @@ export default class BrowserstackConnector {
                 localIdentifier: Date.now(),
 
                 ...parallelRuns ? { parallelRuns } : {},
+                ...verbose ? { verbose } : {},
 
                 //NOTE: additional args use different format
                 'enable-logging-for-api': true


### PR DESCRIPTION
**Problem**
There are a number of options available to control the BrowserStackLocal binary that weren't exposed through this plugin. Not having these options prevents some control and debugging of the `testcafe`-`BrowserStackLocal` integration.

**Solution**
Pass through environment variables to set `logfile`, `verbose`, and `binarypath` options