### PR TITLE
Added support to use proxy when making API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Proxy options can be passed via environment variables.
  - `BROWSERSTACK_PROXY` - a string that specifies a proxy for the BrowserStack local binary. It should have the following structure: `user:pass@proxyHostName:port`,
  - `BROWSERSTACK_LOCAL_PROXY` - a string that specifies a proxy for the local web server. It should have the following structure: `user:pass@proxyHostName:port`,
  - `BROWSERSTACK_FORCE_PROXY` - if it's not empty, forces all traffic of BrowserStack local binary to go through the proxy,
- - `BROWSERSTACK_FORCE_PROXY_FOR_API_REQUESTS` - If it's not empty, forces all api calls to BrowserStack to go through the proxy,
  - `BROWSERSTACK_FORCE_LOCAL` - if it's not empty, forces all traffic of BrowserStack local binary to go through the local machine
  - `BROWSERSTACK_NO_LOCAL` - If it's not empty, forces all traffic of BrowserStack to go over public internet 
 
@@ -62,7 +61,6 @@ export BROWSERSTACK_PROXY="user:p@ssw0rd@proxy.com:8080"
 export BROWSERSTACK_LOCAL_PROXY="admin:12345678@192.168.0.2:8080"
 export BROWSERSTACK_FORCE_PROXY="1"
 export BROWSERSTACK_FORCE_LOCAL="1"
-export BROWSERSTACK_FORCE_PROXY_FOR_API_REQUESTS="1"
 testcafe browserstack:chrome test.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Proxy options can be passed via environment variables.
  - `BROWSERSTACK_PROXY` - a string that specifies a proxy for the BrowserStack local binary. It should have the following structure: `user:pass@proxyHostName:port`,
  - `BROWSERSTACK_LOCAL_PROXY` - a string that specifies a proxy for the local web server. It should have the following structure: `user:pass@proxyHostName:port`,
  - `BROWSERSTACK_FORCE_PROXY` - if it's not empty, forces all traffic of BrowserStack local binary to go through the proxy,
+ - `BROWSERSTACK_FORCE_PROXY_FOR_API_REQUESTS` - If it's not empty, forces all api calls to BrowserStack to go through the proxy,
  - `BROWSERSTACK_FORCE_LOCAL` - if it's not empty, forces all traffic of BrowserStack local binary to go through the local machine
  - `BROWSERSTACK_NO_LOCAL` - If it's not empty, forces all traffic of BrowserStack to go over public internet 
 
@@ -61,6 +62,7 @@ export BROWSERSTACK_PROXY="user:p@ssw0rd@proxy.com:8080"
 export BROWSERSTACK_LOCAL_PROXY="admin:12345678@192.168.0.2:8080"
 export BROWSERSTACK_FORCE_PROXY="1"
 export BROWSERSTACK_FORCE_LOCAL="1"
+export BROWSERSTACK_FORCE_PROXY_FOR_API_REQUESTS="1"
 testcafe browserstack:chrome test.js
 ```
 

--- a/src/utils/request-api.js
+++ b/src/utils/request-api.js
@@ -2,9 +2,11 @@ import Promise from 'pinkie';
 import request from 'request-promise';
 import delay from './delay';
 import * as ERROR_MESSAGES from '../templates/error-messages';
+import isEnvVarTrue from '../utils/is-env-var-true';
 
 
 const API_REQUEST_DELAY = 100;
+const isForcingProxyForApiRequests = () => isEnvVarTrue('BROWSERSTACK_FORCE_PROXY_FOR_API_REQUESTS');
 
 let apiRequestPromise = Promise.resolve(null);
 
@@ -25,7 +27,13 @@ export default function (apiPath, params = {}) {
         qs: { ...queryParams },
 
         method: apiPath.method || 'GET',
-        json:   apiPath.encoding === void 0
+        json:   apiPath.encoding === void 0,
+
+        ...process.env['BROWSERSTACK_PROXY'] && isForcingProxyForApiRequests()
+        ? {
+            proxy: `http://${process.env['BROWSERSTACK_PROXY']}`
+        }
+        : {}
     };
 
     if (body)

--- a/src/utils/request-api.js
+++ b/src/utils/request-api.js
@@ -2,11 +2,8 @@ import Promise from 'pinkie';
 import request from 'request-promise';
 import delay from './delay';
 import * as ERROR_MESSAGES from '../templates/error-messages';
-import isEnvVarTrue from '../utils/is-env-var-true';
-
 
 const API_REQUEST_DELAY = 100;
-const isForcingProxyForApiRequests = () => isEnvVarTrue('BROWSERSTACK_FORCE_PROXY_FOR_API_REQUESTS');
 
 let apiRequestPromise = Promise.resolve(null);
 
@@ -27,14 +24,13 @@ export default function (apiPath, params = {}) {
         qs: { ...queryParams },
 
         method: apiPath.method || 'GET',
-        json:   apiPath.encoding === void 0,
-
-        ...process.env['BROWSERSTACK_PROXY'] && isForcingProxyForApiRequests()
-        ? {
-            proxy: `http://${process.env['BROWSERSTACK_PROXY']}`
-        }
-        : {}
+        json:   apiPath.encoding === void 0
     };
+
+    const proxy = process.env['BROWSERSTACK_PROXY'];
+
+    if (proxy)
+        opts.proxy = `http://${proxy}`;
 
     if (body)
         opts.body = body;


### PR DESCRIPTION
This patch addresses the ECONNREFUSED issues faced when running the provider behind a proxy. Currently, the proxy is only used on Browserstack-Local and is not used when making API Requests to api.browserstack.com. With the 'BROWSERSTACK_FORCE_PROXY_FOR_API_REQUESTS', you can now use the proxy across for API  Requests.