### PR TITLE
Add support for more Browserstack capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,17 @@ BrowserStack Automate allows you to provide options for its internal Selenium Gr
  
 To specify BrowserStack capabilities via the TestCafe BrowserStack provider, use environment variables. This provider supports the following capabilities:
  
-Capability                 | Environment Variable
--------------------------- | --------------------
-`browserstack.debug`       | `BROWSERSTACK_DEBUG`
-`browserstack.console`     | `BROWSERSTACK_CONSOLE`
-`browserstack.networkLogs` | `BROWSERSTACK_NETWORK_LOGS`
-`browserstack.video`       | `BROWSERSTACK_VIDEO`
-`browserstack.timezone`    | `BROWSERSTACK_TIMEZONE`
+Capability                     | Environment Variable
+------------------------------ | --------------------
+`name`                         | `BROWSERSTACK_TEST_RUN_NAME`
+`browserstack.debug`           | `BROWSERSTACK_DEBUG`
+`browserstack.console`         | `BROWSERSTACK_CONSOLE`
+`browserstack.networkLogs`     | `BROWSERSTACK_NETWORK_LOGS`
+`browserstack.video`           | `BROWSERSTACK_VIDEO`
+`browserstack.timezone`        | `BROWSERSTACK_TIMEZONE`
+`browserstack.geoLocation`     | `BROWSERSTACK_GEO_LOCATION`
+`browserstack.customNetwork`   | `BROWSERSTACK_CUSTOM_NETWORK`
+`browserstack.networkProfile`  | `BROWSERSTACK_NETWORK_PROFILE`
  
 Refer to the [BrowserStack documentation](https://www.browserstack.com/automate/capabilities) for information about the values you can specify.
  

--- a/src/index.js
+++ b/src/index.js
@@ -110,11 +110,15 @@ export default {
             ['build', process.env['BROWSERSTACK_BUILD_ID']],
             ['project', process.env['BROWSERSTACK_PROJECT_NAME']],
             ['resolution', process.env['BROWSERSTACK_DISPLAY_RESOLUTION']],
+            ['name', process.env['BROWSERSTACK_TEST_RUN_NAME']],
             ['browserstack.debug', process.env['BROWSERSTACK_DEBUG']],
             ['browserstack.console', process.env['BROWSERSTACK_CONSOLE']],
             ['browserstack.networkLogs', process.env['BROWSERSTACK_NETWORK_LOGS']],
             ['browserstack.video', process.env['BROWSERSTACK_VIDEO']],
             ['browserstack.timezone', process.env['BROWSERSTACK_TIMEZONE']],
+            ['browserstack.geoLocation', process.env['BROWSERSTACK_GEO_LOCATION']],
+            ['browserstack.customNetwork', process.env['BROWSERSTACK_CUSTOM_NETWORK']],
+            ['browserstack.networkProfile', process.env['BROWSERSTACK_NETWORK_PROFILE']]
         ];
 
         return capabilitiesFromEnvironment
@@ -176,7 +180,8 @@ export default {
             pageUrl = 'http://' + browserProxy.targetHost + ':' + browserProxy.proxyPort + parsedPageUrl.path;
         }
 
-        capabilities.name            = `TestCafe test run ${id}`;
+        if (!capabilities.name)
+            capabilities.name            = `TestCafe test run ${id}`;
 
         if (connector) {
             capabilities.localIdentifier = connector.connectorInstance.localIdentifierFlag;

--- a/src/index.js
+++ b/src/index.js
@@ -181,7 +181,7 @@ export default {
         }
 
         if (!capabilities.name)
-            capabilities.name            = `TestCafe test run ${id}`;
+            capabilities.name = `TestCafe test run ${id}`;
 
         if (connector) {
             capabilities.localIdentifier = connector.connectorInstance.localIdentifierFlag;

--- a/test/mocha/browserstack-capabilities-test.js
+++ b/test/mocha/browserstack-capabilities-test.js
@@ -40,7 +40,5 @@ describe('Browserstack capabilities', function () {
             'browserstack.customNetwork':  '"1000", "1000", "100", "1"',
             'browserstack.networkProfile': '4g-lte-lossy'
         });
-
-
     });
 });

--- a/test/mocha/browserstack-capabilities-test.js
+++ b/test/mocha/browserstack-capabilities-test.js
@@ -7,23 +7,31 @@ describe('Browserstack capabilities', function () {
         process.env['BROWSERSTACK_BUILD_ID'] = 'build-1';
         process.env['BROWSERSTACK_PROJECT_NAME'] = 'project-1';
         process.env['BROWSERSTACK_DISPLAY_RESOLUTION'] = '1024x768';
+        process.env['BROWSERSTACK_TEST_RUN_NAME'] = 'Testcafe test run 1';
         process.env['BROWSERSTACK_DEBUG'] = 'true';
         process.env['BROWSERSTACK_CONSOLE'] = 'errors';
         process.env['BROWSERSTACK_NETWORK_LOGS'] = 'true';
         process.env['BROWSERSTACK_VIDEO'] = 'true';
         process.env['BROWSERSTACK_TIMEZONE'] = 'Asia/Taipei';
+        process.env['BROWSERSTACK_GEO_LOCATION'] = 'ZA';
+        process.env['BROWSERSTACK_CUSTOM_NETWORK'] = '"1000", "1000", "100", "1"';
+        process.env['BROWSERSTACK_NETWORK_PROFILE'] = '4g-lte-lossy';
 
         const output = browserStackProvider._getAdditionalCapabilities({});
 
         expect(output).to.deep.equal({
-            'build':                    'build-1',
-            'project':                  'project-1',
-            'resolution':               '1024x768',
-            'browserstack.debug':       'true',
-            'browserstack.console':     'errors',
-            'browserstack.networkLogs': 'true',
-            'browserstack.video':       'true',
-            'browserstack.timezone':    'Asia/Taipei'
+            'build':                         'build-1',
+            'project':                       'project-1',
+            'resolution':                    '1024x768',
+            'name':                          'Testcafe test run 1',
+            'browserstack.debug':            'true',
+            'browserstack.console':          'errors',
+            'browserstack.networkLogs':      'true',
+            'browserstack.video':            'true',
+            'browserstack.timezone':         'Asia/Taipei',
+            'browserstack.geoLocation':      'ZA',
+            'browserstack.customNetwork':    '"1000", "1000", "100", "1"',
+            'browserstack.networkProfile':   '4g-lte-lossy'
         });
     });
 });

--- a/test/mocha/browserstack-capabilities-test.js
+++ b/test/mocha/browserstack-capabilities-test.js
@@ -3,6 +3,13 @@ var browserStackProvider = require('../../');
 
 
 describe('Browserstack capabilities', function () {
+    after(function () { 
+        delete process.env.BROWSERSTACK_TEST_RUN_NAME;
+        delete process.env.BROWSERSTACK_GEO_LOCATION;
+        delete process.env.BROWSERSTACK_CUSTOM_NETWORK;
+        delete process.env.BROWSERSTACK_NETWORK_PROFILE;
+    });
+
     it('Should add custom capabilities from environment variables', function () {
         process.env['BROWSERSTACK_BUILD_ID'] = 'build-1';
         process.env['BROWSERSTACK_PROJECT_NAME'] = 'project-1';
@@ -20,18 +27,20 @@ describe('Browserstack capabilities', function () {
         const output = browserStackProvider._getAdditionalCapabilities({});
 
         expect(output).to.deep.equal({
-            'build':                         'build-1',
-            'project':                       'project-1',
-            'resolution':                    '1024x768',
-            'name':                          'Testcafe test run 1',
-            'browserstack.debug':            'true',
-            'browserstack.console':          'errors',
-            'browserstack.networkLogs':      'true',
-            'browserstack.video':            'true',
-            'browserstack.timezone':         'Asia/Taipei',
-            'browserstack.geoLocation':      'ZA',
-            'browserstack.customNetwork':    '"1000", "1000", "100", "1"',
-            'browserstack.networkProfile':   '4g-lte-lossy'
+            'build':                       'build-1',
+            'project':                     'project-1',
+            'resolution':                  '1024x768',
+            'name':                        'Testcafe test run 1',
+            'browserstack.debug':          'true',
+            'browserstack.console':        'errors',
+            'browserstack.networkLogs':    'true',
+            'browserstack.video':          'true',
+            'browserstack.timezone':       'Asia/Taipei',
+            'browserstack.geoLocation':    'ZA',
+            'browserstack.customNetwork':  '"1000", "1000", "100", "1"',
+            'browserstack.networkProfile': '4g-lte-lossy'
         });
+
+
     });
 });


### PR DESCRIPTION
@AndreyBelym 

**Problem:**
Right now, there is no support for the setting these Browserstack capabilities:

- name
- browserstack.geoLocation
- browserstack.customNetwork
- browserstack.networkProfile

**Solution:**
Create new environment variables that could be used to set these capabilities.