### PR TITLE
Capability to run testcafe as SSL certified server

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ To specify BrowserStack capabilities via the TestCafe BrowserStack provider, use
 Capability                    | Environment Variable
 ----------------------------- | --------------------
 `name`                        | `BROWSERSTACK_TEST_RUN_NAME`
+`acceptSslCerts`              | `BROWSERSTACK_ACCEPT_SSL_CERTS`
 `browserstack.debug`          | `BROWSERSTACK_DEBUG`
 `browserstack.console`        | `BROWSERSTACK_CONSOLE`
 `browserstack.networkLogs`    | `BROWSERSTACK_NETWORK_LOGS`

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,8 @@ export default {
             ['browserstack.timezone', process.env['BROWSERSTACK_TIMEZONE']],
             ['browserstack.geoLocation', process.env['BROWSERSTACK_GEO_LOCATION']],
             ['browserstack.customNetwork', process.env['BROWSERSTACK_CUSTOM_NETWORK']],
-            ['browserstack.networkProfile', process.env['BROWSERSTACK_NETWORK_PROFILE']]
+            ['browserstack.networkProfile', process.env['BROWSERSTACK_NETWORK_PROFILE']],
+            ['acceptSslCerts', true]
         ];
 
         return capabilitiesFromEnvironment

--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ export default {
             ['browserstack.geoLocation', process.env['BROWSERSTACK_GEO_LOCATION']],
             ['browserstack.customNetwork', process.env['BROWSERSTACK_CUSTOM_NETWORK']],
             ['browserstack.networkProfile', process.env['BROWSERSTACK_NETWORK_PROFILE']],
-            ['acceptSslCerts' , process.env['BROWSERSTACK_ACCEPT_SSL_CERTS']]
+            ['acceptSslCerts', process.env['BROWSERSTACK_ACCEPT_SSL_CERTS']]
         ];
 
         return capabilitiesFromEnvironment

--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ export default {
             ['browserstack.geoLocation', process.env['BROWSERSTACK_GEO_LOCATION']],
             ['browserstack.customNetwork', process.env['BROWSERSTACK_CUSTOM_NETWORK']],
             ['browserstack.networkProfile', process.env['BROWSERSTACK_NETWORK_PROFILE']],
-            ['acceptSslCerts', true]
+            ['acceptSslCerts' , process.env['BROWSERSTACK_ACCEPT_SSL_CERTS']]
         ];
 
         return capabilitiesFromEnvironment


### PR DESCRIPTION
When you need to test your web application which mandates tescafe to be invoked with _https_ , **acceptSslCerts** needs to be set specially for testing on **non chrome** browsers. (chrome works with _--allow-insecure-localhost_ option) 