### PR TITLE
Improve Stability of BrowserStack Local Tests

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -95,14 +95,15 @@ export default class BrowserstackConnector {
 
     destroy () {
         return new Promise((resolve, reject) => {
-            this.connectorInstance.stop(err => {
-                if (err) {
-                    reject(err);
-                    return;
-                }
-
-                resolve();
-            });
+            setTimeout(() => {
+                this.connectorInstance.stop(err => {
+                    if (err) {
+                        reject(err);
+                        return;
+                    }
+                    resolve();
+                });
+            }, 1000);
         });
     }
 }


### PR DESCRIPTION
This timeout gives an extra 1 sec for the browser to complete all the pending requests. This will improve the session stability as all the internal URLs will resolve at the session end.