### PR TITLE
fix: session restart message on heartbeat lapse

### DIFF
--- a/src/utils/create-browserstack-status.js
+++ b/src/utils/create-browserstack-status.js
@@ -1,14 +1,17 @@
 export default function (jobResult, jobData, possibleResults) {
-    var testsFailed = jobResult === possibleResults.done ? jobData.total - jobData.passed : 0;
-    var jobPassed   = jobResult === possibleResults.done && testsFailed === 0;
-    var errorReason = '';
+    const testsFailed = jobResult === possibleResults.done ? jobData.total - jobData.passed : 0;
+    const jobPassed   = jobResult === possibleResults.done && testsFailed === 0 ||
+        jobResult === possibleResults.restarted;
+    let errorReason = '';
 
     if (testsFailed > 0)
         errorReason = `${testsFailed} tests failed`;
     else if (jobResult === possibleResults.errored)
         errorReason = jobData.message;
     else if (jobResult === possibleResults.aborted)
-        errorReason = 'Session aborted';
+        errorReason = 'Session interrupted';
+    else if (jobResult === possibleResults.restarted)
+        errorReason = 'Session restarted';
 
     return {
         status: jobPassed ? 'passed' : 'failed',


### PR DESCRIPTION
When the heartbeat for the connection gets lased there is a process for
restarting the active connection to see if it helps. When restarting the
active connection we try to close and open the browser which on a cloud
provider means creation of a new session, this inturn updates the
mapping of the browser id with the session id and thus when the process
is getting closed the previous old sessions remains unmarked on the user
dashboard.

We can basically mark the connection before closing the browser, with
the remark of restarting becasue, then user will be aware that the
session is restarted and won't be unmarked.

Ref: https://github.com/DevExpress/testcafe/pull/5535