### PR TITLE
Bump up jimp dependency to v0.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dedent": "^0.7.0",
     "desired-capabilities": "^0.1.0",
     "firefox-profile": "^1.3.1",
-    "jimp": "^0.10.3",
+    "jimp": "^0.16.1",
     "lodash": "^4.17.15",
     "mime-db": "^1.43.0",
     "os-family": "^1.0.0",


### PR DESCRIPTION
In the newest `jimp` release [v0.16.1](https://github.com/oliver-moran/jimp/releases/tag/v0.16.1) there's a security upgrade to `jpeg-js`.

The rationale behind it is:
> Uncontrolled resource consumption in jpeg-js before 0.4.0 may allow attacker to launch denial of service attacks using specially a crafted JPEG image.