### PR TITLE
removing the hardcoded pageurl for android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -238,13 +238,6 @@ module.exports = {
             capabilities.localIdentifier = connector.connectorInstance.localIdentifierFlag;
         }
 
-        if (capabilities.os.toLowerCase() === 'android') {
-            const parsedPageUrl = parseUrl(pageUrl);
-            const browserProxy  = await this._getBrowserProxy(parsedPageUrl.hostname, parsedPageUrl.port);
-
-            pageUrl = 'http://' + browserProxy.targetHost + ':' + browserProxy.proxyPort + parsedPageUrl.path;
-        }
-
         if (!capabilities.name)
             capabilities.name = `TestCafe test run ${id}`;
 


### PR DESCRIPTION
Fixing the issue of session not running on https server for android. Have removed the hardcoded pageurl.