### PR TITLE
feat: use latest stable version by default

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -14,7 +14,6 @@ function clean () {
 }
 
 function lint () {
-
     return gulp
         .src([
             'src/**/*.js',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-provider-browserstack",
-  "version": "1.13.2-alpha.1",
+  "version": "1.13.2",
   "description": "browserstack TestCafe browser provider plugin.",
   "repository": "https://github.com/DevExpress/testcafe-browser-provider-browserstack",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ module.exports = {
     },
 
     _filterPlatformInfo (query) {
-        return this.platformsInfo
+        let filteredPlatformInfo = this.platformsInfo
             .filter(info => {
                 var browserNameMatched = info['browser'] && info['browser'].toLowerCase() === query.name;
                 var deviceNameMatched  = info['device'] && info['device'].toLowerCase() === query.name;
@@ -174,6 +174,16 @@ module.exports = {
 
                 return desktopBrowserMatched || mobileBrowserMatched;
             });
+
+        if (filteredPlatformInfo.length && query.version === 'any') {
+            filteredPlatformInfo = filteredPlatformInfo.filter(info => {
+                const browserVersion = info['browser_version'] || '';
+
+                return !browserVersion.includes('beta');
+            });
+        }
+
+        return filteredPlatformInfo;
     },
 
     _generateBrowserNames () {

--- a/test/mocha/browser-names-test.js
+++ b/test/mocha/browser-names-test.js
@@ -1,6 +1,6 @@
-var expect               = require('chai').expect;
-var Promise              = require('pinkie');
-var browserStackProvider = require('../../');
+const { expect }           = require('chai');
+const Promise              = require('pinkie');
+const browserStackProvider = require('../../');
 
 
 describe('Browser names', function () {
@@ -54,35 +54,22 @@ describe('Browser names', function () {
     });
 
     it('Should validate browser names', function () {
-        var browserNames = [
-            'chrome',
-            'safari',
-            'opera:windows',
-            'firefox:os x',
-            'edge',
-            'ie@9',
-            'ie@10.0:Windows 8',
-            'ie@11:Windows 10',
-            'iPhone SE',
-            'Google Nexus 5',
-            'ie@5.0',
-            'ie@11:os x'
-        ];
+        var browserNameResults = {
+            'chrome':             true,
+            'safari':             true,
+            'opera:windows':      true,
+            'firefox:os x':       true,
+            'edge':               true,
+            'ie@9.0:Windows 7':   true,
+            'ie@10.0:Windows 8':  true,
+            'ie@11.0:Windows 10': true,
+            'iPhone SE':          true,
+            'Google Nexus 5':     true,
+            'ie@5.0':             false,
+            'ie@11:os x':         false
+        };
 
-        var expectedResults = [
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-            false,
-            false
-        ];
+        const browserNames = Object.keys(browserNameResults);
 
         var validationPromises = browserNames
             .map(function (browserName) {
@@ -92,7 +79,16 @@ describe('Browser names', function () {
         return Promise
             .all(validationPromises)
             .then(function (results) {
-                expect(results).to.deep.equals(expectedResults);
+                const expectedResults = Object.values(browserNameResults);
+
+                for (let i = 0; i < results.length; i++)
+                    expect(results[i]).eql(expectedResults[i], 'invalid result for ' + browserNames[i]);
             });
+    });
+
+    it("Should not return the 'beta' browser version if the version is not specified", () => {
+        const capability = browserStackProvider._generateBasicCapabilities('chrome');
+
+        expect(capability['browser_version']).to.not.include('beta');
     });
 });

--- a/test/mocha/browserstack-capabilities-test.js
+++ b/test/mocha/browserstack-capabilities-test.js
@@ -43,7 +43,7 @@ describe('Browserstack capabilities', function () {
         });
     });
 
-    it('Should read aditional capabilities from a config file', () => {
+    it('Should read additional capabilities from a config file', () => {
         process.env.BROWSERSTACK_CAPABILITIES_CONFIG_PATH = require.resolve('./data/capabilities-config.json');
 
         const capabilities = browserStackProvider._getAdditionalCapabilities();


### PR DESCRIPTION
If the browser name is not specified, the provider will use the first version without the `beta` suffix.