### PR TITLE
feat: support for `BROWSERSTACK_BUILD_NAME` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ To specify BrowserStack capabilities via the TestCafe BrowserStack provider, use
 Capability                    | Environment Variable
 ----------------------------- | ---------------------------------
 `project`                     | `BROWSERSTACK_PROJECT_NAME`
-`build`                       | `BROWSERSTACK_BUILD_ID`
+`build`                       | `BROWSERSTACK_BUILD_ID` (`BROWSERSTACK_BUILD_NAME` may also be used)
 `resolution`                  | `BROWSERSTACK_DISPLAY_RESOLUTION`
 `name`                        | `BROWSERSTACK_TEST_RUN_NAME`
 `acceptSslCerts`              | `BROWSERSTACK_ACCEPT_SSL_CERTS`

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ module.exports = {
         // For the full list of capabilities, see https://www.browserstack.com/automate/capabilities
 
         return {
-            'build':                       process.env['BROWSERSTACK_BUILD_ID'],
+            'build':                       process.env['BROWSERSTACK_BUILD_ID'] || process.env['BROWSERSTACK_BUILD_NAME'],
             'project':                     process.env['BROWSERSTACK_PROJECT_NAME'],
             'resolution':                  process.env['BROWSERSTACK_DISPLAY_RESOLUTION'],
             'name':                        process.env['BROWSERSTACK_TEST_RUN_NAME'],


### PR DESCRIPTION

closes #174 