### PR TITLE
Add protocol argument to browser-proxy, allowing run using https for Android devices

### DIFF
--- a/src/browser-proxy.js
+++ b/src/browser-proxy.js
@@ -4,11 +4,12 @@ import Promise from 'pinkie';
 
 
 module.exports = class BrowserProxy {
-    constructor (targetHost, targetPort, { proxyPort, responseDelay } = {}) {
-        this.targetHost    = targetHost;
-        this.targetPort    = targetPort;
-        this.proxyPort     = proxyPort || 0;
-        this.responseDelay = responseDelay || 0;
+    constructor (targetHost, targetPort, { targetProtocol, proxyPort, responseDelay } = {}) {
+        this.targetProtocol = targetProtocol || 'http';
+        this.targetHost     = targetHost;
+        this.targetPort     = targetPort;
+        this.proxyPort      = proxyPort || 0;
+        this.responseDelay  = responseDelay || 0;
 
         this.server = http.createServer((...args) => this._onBrowserRequest(...args));
 
@@ -18,7 +19,7 @@ module.exports = class BrowserProxy {
     _onBrowserRequest (req, res) {
         setTimeout(() => {
             const parsedRequestUrl = parseUrl(req.url);
-            const destinationUrl   = 'http://' + this.targetHost + ':' + this.targetPort + parsedRequestUrl.path;
+            const destinationUrl   = this.targetProtocol + '//' + this.targetHost + ':' + this.targetPort + parsedRequestUrl.path;
 
             res.statusCode = 302;
 

--- a/src/index.js
+++ b/src/index.js
@@ -65,11 +65,11 @@ module.exports = {
         return this.connectorPromise;
     },
 
-    _getBrowserProxy (host, port) {
+    _getBrowserProxy (protocol, host, port) {
         this.browserProxyPromise = this.browserProxyPromise
             .then(async browserProxy => {
                 if (!browserProxy) {
-                    browserProxy = new BrowserProxy(host, port, { responseDelay: ANDROID_PROXY_RESPONSE_DELAY });
+                    browserProxy = new BrowserProxy(host, port, { targetProtocol: protocol, responseDelay: ANDROID_PROXY_RESPONSE_DELAY });
 
                     await browserProxy.init();
                 }
@@ -250,7 +250,7 @@ module.exports = {
 
         if (capabilities.os.toLowerCase() === 'android') {
             const parsedPageUrl = parseUrl(pageUrl);
-            const browserProxy  = await this._getBrowserProxy(parsedPageUrl.hostname, parsedPageUrl.port);
+            const browserProxy  = await this._getBrowserProxy(parsedPageUrl.protocol, parsedPageUrl.hostname, parsedPageUrl.port);
 
             pageUrl = 'http://' + browserProxy.targetHost + ':' + browserProxy.proxyPort + parsedPageUrl.path;
         }

--- a/test/mocha/browser-names-test.js
+++ b/test/mocha/browser-names-test.js
@@ -27,7 +27,8 @@ describe('Browser names', function () {
             'ie@10.0:Windows 8',
             'ie@11.0:Windows 8.1',
             'edge@15.0:Windows 10',
-            'iPhone SE@11',
+            //'iPhone SE@11', iPhone SE@11 is not included in https://www.browserstack.com/list-of-browsers-and-platforms/automate failing the test
+            'iPhone SE 2020@13',
             'iPhone XR@12',
             'Google Pixel 7@13.0'
         ];
@@ -41,7 +42,8 @@ describe('Browser names', function () {
             'ie@11.0:Windows 8.1',
             'edge@15.0:Windows 10',
             'iPhone 7@10',
-            'iPhone SE@11',
+            //'iPhone SE@11', iPhone SE@11 is not included in https://www.browserstack.com/list-of-browsers-and-platforms/automate failing the test
+            'iPhone SE 2020@13',
             'iPhone XR@12',
             'Google Pixel 7@13.0'
         ];

--- a/test/mocha/browser-names-test.js
+++ b/test/mocha/browser-names-test.js
@@ -27,7 +27,6 @@ describe('Browser names', function () {
             'ie@10.0:Windows 8',
             'ie@11.0:Windows 8.1',
             'edge@15.0:Windows 10',
-            //'iPhone SE@11', iPhone SE@11 is not included in https://www.browserstack.com/list-of-browsers-and-platforms/automate failing the test
             'iPhone SE 2020@13',
             'iPhone XR@12',
             'Google Pixel 7@13.0'
@@ -42,7 +41,6 @@ describe('Browser names', function () {
             'ie@11.0:Windows 8.1',
             'edge@15.0:Windows 10',
             'iPhone 7@10',
-            //'iPhone SE@11', iPhone SE@11 is not included in https://www.browserstack.com/list-of-browsers-and-platforms/automate failing the test
             'iPhone SE 2020@13',
             'iPhone XR@12',
             'Google Pixel 7@13.0'

--- a/test/mocha/browser-names-test.js
+++ b/test/mocha/browser-names-test.js
@@ -65,7 +65,7 @@ describe('Browser names', function () {
             'ie@9.0:Windows 7':   true,
             'ie@10.0:Windows 8':  true,
             'ie@11.0:Windows 10': true,
-            'iPhone SE':          true,
+            'iPhone SE 2020':     true,
             'Google Pixel 7':     true,
             'ie@5.0':             false,
             'ie@11:os x':         false


### PR DESCRIPTION
Currently, Android executions use the browser-proxy implementation which has defined as the target URL the protocol static to http. However, if I run my TestCafe tests using [ssl options](https://testcafe.io/documentation/402839/guides/advanced-guides/test-https-features-and-http2-websites#generate-a-certificate-in-your-code), I receive an error, since the proxy is always targeting to a http URL.

This PR is related to the issue #162 and add an argument with the protocol to the browser-proxy based on the target URL, so the proxy target can have the same protocol from the actual target URL.

In addition to that, I fixed the tests `Should return list of common browsers and devices` and `Should validate browser names`, which were validating a list of common browsers, but the `iPhone SE` alias used in the test is not listed in the BrowserStack API/[documentation](https://www.browserstack.com/list-of-browsers-and-platforms/automate)

[closes #162]