### PR TITLE
Add protocol argument to browser-proxy, allowing run using https for …

### DIFF
--- a/src/browser-proxy.js
+++ b/src/browser-proxy.js
@@ -4,11 +4,12 @@ import Promise from 'pinkie';
 
 
 module.exports = class BrowserProxy {
-    constructor (targetHost, targetPort, { proxyPort, responseDelay } = {}) {
-        this.targetHost    = targetHost;
-        this.targetPort    = targetPort;
-        this.proxyPort     = proxyPort || 0;
-        this.responseDelay = responseDelay || 0;
+    constructor (targetHost, targetPort, { targetProtocol, proxyPort, responseDelay } = {}) {
+        this.targetProtocol = targetProtocol || 'http';
+        this.targetHost     = targetHost;
+        this.targetPort     = targetPort;
+        this.proxyPort      = proxyPort || 0;
+        this.responseDelay  = responseDelay || 0;
 
         this.server = http.createServer((...args) => this._onBrowserRequest(...args));
 
@@ -18,7 +19,7 @@ module.exports = class BrowserProxy {
     _onBrowserRequest (req, res) {
         setTimeout(() => {
             const parsedRequestUrl = parseUrl(req.url);
-            const destinationUrl   = 'http://' + this.targetHost + ':' + this.targetPort + parsedRequestUrl.path;
+            const destinationUrl   = this.targetProtocol + '//' + this.targetHost + ':' + this.targetPort + parsedRequestUrl.path;
 
             res.statusCode = 302;
 

--- a/src/index.js
+++ b/src/index.js
@@ -65,11 +65,11 @@ module.exports = {
         return this.connectorPromise;
     },
 
-    _getBrowserProxy (host, port) {
+    _getBrowserProxy (protocol, host, port) {
         this.browserProxyPromise = this.browserProxyPromise
             .then(async browserProxy => {
                 if (!browserProxy) {
-                    browserProxy = new BrowserProxy(host, port, { responseDelay: ANDROID_PROXY_RESPONSE_DELAY });
+                    browserProxy = new BrowserProxy(host, port, { targetProtocol: protocol, responseDelay: ANDROID_PROXY_RESPONSE_DELAY });
 
                     await browserProxy.init();
                 }
@@ -250,7 +250,7 @@ module.exports = {
 
         if (capabilities.os.toLowerCase() === 'android') {
             const parsedPageUrl = parseUrl(pageUrl);
-            const browserProxy  = await this._getBrowserProxy(parsedPageUrl.hostname, parsedPageUrl.port);
+            const browserProxy  = await this._getBrowserProxy(parsedPageUrl.protocol, parsedPageUrl.hostname, parsedPageUrl.port);
 
             pageUrl = 'http://' + browserProxy.targetHost + ':' + browserProxy.proxyPort + parsedPageUrl.path;
         }

--- a/test/mocha/browser-names-test.js
+++ b/test/mocha/browser-names-test.js
@@ -27,7 +27,7 @@ describe('Browser names', function () {
             'ie@10.0:Windows 8',
             'ie@11.0:Windows 8.1',
             'edge@15.0:Windows 10',
-            'iPhone SE@11',
+            'iPhone SE 2020@13',
             'iPhone XR@12',
             'Google Pixel 7@13.0'
         ];
@@ -41,7 +41,7 @@ describe('Browser names', function () {
             'ie@11.0:Windows 8.1',
             'edge@15.0:Windows 10',
             'iPhone 7@10',
-            'iPhone SE@11',
+            'iPhone SE 2020@13',
             'iPhone XR@12',
             'Google Pixel 7@13.0'
         ];
@@ -63,7 +63,7 @@ describe('Browser names', function () {
             'ie@9.0:Windows 7':   true,
             'ie@10.0:Windows 8':  true,
             'ie@11.0:Windows 10': true,
-            'iPhone SE':          true,
+            'iPhone SE 2020':     true,
             'Google Pixel 7':     true,
             'ie@5.0':             false,
             'ie@11:os x':         false


### PR DESCRIPTION
…Android devices (#211)

* Included the target protocol in the browser proxy, which is used when run in an Android device and fixed the test that validate the common browsers with a not existing iPhone version

* Update the Iphone SE test case name for the browser-names-test.js 'Should validate browser names'

* Removing comments from the browser-names-test.js

---------