### PR TITLE
fix #152 - modify browserstack config file path to work

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,18 +138,27 @@ module.exports = {
     },
 
     _getCapabilitiesFromConfig () {
-        const configPath = String(path.relative(__dirname, path.resolve(process.env.BROWSERSTACK_CAPABILITIES_CONFIG_PATH)));
+        const configPath = path.resolve(process.env.BROWSERSTACK_CAPABILITIES_CONFIG_PATH);
 
         if (!configPath)
             return {};
+        const relativeConfigPath = path.relative(__dirname, configPath);
 
-        return require(configPath);
+        if (!relativeConfigPath)
+            return {};
+        return require(relativeConfigPath);
     },
 
     _getAdditionalCapabilities () {
         const capabilitiesFromEnvironment = pickBy(this._getCapabilitiesFromEnvironment(), value => value !== void 0);
+        let additionalCapabilities = '';
 
-        return { ...this._getCapabilitiesFromConfig(), ...capabilitiesFromEnvironment };
+        if (process.env.BROWSERSTACK_CAPABILITIES_CONFIG_PATH)
+            additionalCapabilities = { ...this._getCapabilitiesFromConfig(), ...capabilitiesFromEnvironment };
+        else
+            additionalCapabilities = { ...capabilitiesFromEnvironment };
+
+        return additionalCapabilities;
     },
 
     _filterPlatformInfo (query) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { parse as parseUrl } from 'url';
+import path from 'node:path';
 import Promise from 'pinkie';
 import { promisify } from 'util';
 import parseCapabilities from 'desired-capabilities';
@@ -137,7 +138,7 @@ module.exports = {
     },
 
     _getCapabilitiesFromConfig () {
-        const configPath = process.env.BROWSERSTACK_CAPABILITIES_CONFIG_PATH;
+        const configPath = String(path.relative(__dirname, path.resolve(process.env.BROWSERSTACK_CAPABILITIES_CONFIG_PATH)));
 
         if (!configPath)
             return {};

--- a/src/index.js
+++ b/src/index.js
@@ -138,27 +138,23 @@ module.exports = {
     },
 
     _getCapabilitiesFromConfig () {
-        const configPath = path.resolve(process.env.BROWSERSTACK_CAPABILITIES_CONFIG_PATH);
+        let relativeConfigPath;
 
-        if (!configPath)
-            return {};
-        const relativeConfigPath = path.relative(__dirname, configPath);
+        if (process.env.BROWSERSTACK_CAPABILITIES_CONFIG_PATH) {
+            const configPath = path.resolve(process.env.BROWSERSTACK_CAPABILITIES_CONFIG_PATH);
 
-        if (!relativeConfigPath)
+            relativeConfigPath = path.relative(__dirname, configPath);
+        }
+        else
             return {};
+
         return require(relativeConfigPath);
     },
 
     _getAdditionalCapabilities () {
         const capabilitiesFromEnvironment = pickBy(this._getCapabilitiesFromEnvironment(), value => value !== void 0);
-        let additionalCapabilities = '';
 
-        if (process.env.BROWSERSTACK_CAPABILITIES_CONFIG_PATH)
-            additionalCapabilities = { ...this._getCapabilitiesFromConfig(), ...capabilitiesFromEnvironment };
-        else
-            additionalCapabilities = { ...capabilitiesFromEnvironment };
-
-        return additionalCapabilities;
+        return { ...this._getCapabilitiesFromConfig(), ...capabilitiesFromEnvironment };
     },
 
     _filterPlatformInfo (query) {

--- a/test/mocha/browserstack-capabilities-test.js
+++ b/test/mocha/browserstack-capabilities-test.js
@@ -63,4 +63,38 @@ describe('Browserstack capabilities', function () {
             'browserstack.networkProfile': '4g-lte-lossy'
         });
     });
+
+    it('Should add additional capabilities when both config file and environment variables used', () => {
+        process.env['BROWSERSTACK_BUILD_ID'] = 'build-1';
+        process.env['BROWSERSTACK_PROJECT_NAME'] = 'project-1';
+        process.env['BROWSERSTACK_DISPLAY_RESOLUTION'] = '1024x768';
+        process.env['BROWSERSTACK_TEST_RUN_NAME'] = 'Testcafe test run 1';
+        process.env['BROWSERSTACK_DEBUG'] = 'false'; //env var should take precedence
+        process.env['BROWSERSTACK_CONSOLE'] = 'errors';
+        process.env['BROWSERSTACK_NETWORK_LOGS'] = 'true';
+        process.env['BROWSERSTACK_VIDEO'] = 'true';
+        process.env['BROWSERSTACK_TIMEZONE'] = 'Asia/Taipei';
+        process.env['BROWSERSTACK_GEO_LOCATION'] = 'ZA';
+        process.env['BROWSERSTACK_CUSTOM_NETWORK'] = '"1000", "1000", "100", "1"';
+        process.env['BROWSERSTACK_NETWORK_PROFILE'] = '4g-lte-lossy';
+
+        process.env.BROWSERSTACK_CAPABILITIES_CONFIG_PATH = require.resolve('./data/capabilities-config.json');
+
+        const capabilities = browserStackProvider._getAdditionalCapabilities();
+
+        expect(capabilities).to.deep.equal({
+            'build':                       'build-1',
+            'project':                     'project-1',
+            'resolution':                  '1024x768',
+            'name':                        'Testcafe test run 1',
+            'browserstack.debug':          'false', //env var should take precedence
+            'browserstack.console':        'errors',
+            'browserstack.networkLogs':    'true',
+            'browserstack.video':          'true',
+            'browserstack.timezone':       'Asia/Taipei',
+            'browserstack.geoLocation':    'ZA',
+            'browserstack.customNetwork':  '"1000", "1000", "100", "1"',
+            'browserstack.networkProfile': '4g-lte-lossy'
+        });
+    });
 });


### PR DESCRIPTION
This change will modify the provided config file path to match the relative path of the file needed by the plugin to resolve it correctly.